### PR TITLE
getCurrentUri to protected

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -327,7 +327,7 @@ class Router {
 	 * Define the current relative URI
 	 * @return string
 	 */
-	private function getCurrentUri() {
+	protected function getCurrentUri() {
 
 		// Get the current Request URI and remove rewrite basepath from it (= allows one to run the router in a subfolder)
 		$basepath = implode('/', array_slice(explode('/', $_SERVER['SCRIPT_NAME']), 0, -1)) . '/';


### PR DESCRIPTION
Why? Because `getCurrentUri()` does not do what I would like it to do, and I do not see any overall fix (see #13).