### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-composer.lock
-vendor/
+/composer.lock
+/vendor/
 tests-report/

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		{
 			"name": "Bram(us) Van Damme",
 			"email": "bramus@bram.us",
-            "homepage": "http://www.bram.us"
+			"homepage": "http://www.bram.us"
 		}
 	],
 	"require": {

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -82,6 +82,17 @@ class Router {
 
 	}
 
+	/*
+	 * Shorthand for a route accessed using any method
+	 * 
+	 * @param string $pattern A route pattern such as /about/system
+	 * @param object|callable $fn The handling function to be executed
+	 */
+	public function all($pattern, $fn) {
+
+		$this->match('GET|POST|PUT|DELETE|OPTIONS|PATCH|HEAD', $fn);
+
+	}
 
 	/**
 	 * Shorthand for a route accessed using GET

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -25,7 +25,7 @@ class Router {
 	/**
 	 * @var object|callable The function to be executed when no route has been matched
 	 */
-	private $notFound;
+	protected $notFound;
 
 
 	/**

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -89,9 +89,7 @@ class Router {
 	 * @param object|callable $fn The handling function to be executed
 	 */
 	public function all($pattern, $fn) {
-
 		$this->match('GET|POST|PUT|DELETE|OPTIONS|PATCH|HEAD', $fn);
-
 	}
 
 	/**

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -236,7 +236,7 @@ class Router {
 	 *
 	 * @param object|callable $callback Function to be executed after a matching route was handled (= after router middleware)
 	 */
-	public function run($callback = null, $trigger404 = true) {
+	public function run($callback = null) {
 
 		// Define which method we need to handle
 		$this->method = $this->getRequestMethod();
@@ -251,7 +251,7 @@ class Router {
 			$numHandled = $this->handle($this->routes[$this->method], true);
 
 		// If no route was handled, trigger the 404 (if any)
-		if ($numHandled === 0 && $trigger404 === true) {
+		if ($numHandled === 0) {
 			if ($this->notFound && is_callable($this->notFound)) call_user_func($this->notFound);
 			else header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
 		}

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -251,7 +251,7 @@ class Router {
 			$numHandled = $this->handle($this->routes[$this->method], true);
 
 		// If no route was handled, trigger the 404 (if any)
-		if ($numHandled == 0 && $trigger404 === true) {
+		if ($numHandled === 0 && $trigger404 === true) {
 			if ($this->notFound && is_callable($this->notFound)) call_user_func($this->notFound);
 			else header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
 		}
@@ -262,6 +262,10 @@ class Router {
 
 		// If it originally was a HEAD request, clean up after ourselves by emptying the output buffer
 		if ($_SERVER['REQUEST_METHOD'] == 'HEAD') ob_end_clean();
+		
+		// Return true if a route was handled, false otherwise
+		if ($numHandled === 0) return false;
+		return true;
 
 	}
 

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -89,7 +89,7 @@ class Router {
 	 * @param object|callable $fn The handling function to be executed
 	 */
 	public function all($pattern, $fn) {
-		$this->match('GET|POST|PUT|DELETE|OPTIONS|PATCH|HEAD', $fn);
+		$this->match('GET|POST|PUT|DELETE|OPTIONS|PATCH|HEAD', $pattern, $fn);
 	}
 
 	/**

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -227,7 +227,7 @@ class Router {
 	 *
 	 * @param object|callable $callback Function to be executed after a matching route was handled (= after router middleware)
 	 */
-	public function run($callback = null) {
+	public function run($callback = null, $trigger404 = true) {
 
 		// Define which method we need to handle
 		$this->method = $this->getRequestMethod();
@@ -242,7 +242,7 @@ class Router {
 			$numHandled = $this->handle($this->routes[$this->method], true);
 
 		// If no route was handled, trigger the 404 (if any)
-		if ($numHandled == 0) {
+		if ($numHandled == 0 && $trigger404 === true) {
 			if ($this->notFound && is_callable($this->notFound)) call_user_func($this->notFound);
 			else header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
 		}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -2,537 +2,592 @@
 
 class RouterTest extends PHPUnit_Framework_TestCase {
 
-	protected function setUp() {
+    protected function setUp() {
 
-		// Clear SCRIPT_NAME because bramus/router tries to guess the subfolder the script is run in
-		$_SERVER['SCRIPT_NAME'] = '/index.php';
+        // Clear SCRIPT_NAME because bramus/router tries to guess the subfolder the script is run in
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		// Default request method to GET
-		$_SERVER['REQUEST_METHOD'] = 'GET';
+        // Default request method to GET
+        $_SERVER['REQUEST_METHOD'] = 'GET';
 
-		// Default SERVER_PROTOCOL method to HTTP/1.1
-		$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+        // Default SERVER_PROTOCOL method to HTTP/1.1
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
-	}
+    }
 
-	protected function tearDown() {
-		// nothing
-	}
+    protected function tearDown() {
+        // nothing
+    }
 
-	public function testInit() {
-		$this->assertInstanceOf('\Bramus\Router\Router', new \Bramus\Router\Router());
-	}
+    public function testInit() {
+        $this->assertInstanceOf('\Bramus\Router\Router', new \Bramus\Router\Router());
+    }
 
-	public function testUri() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->match('GET', '/about', function() {
-			echo 'about';
-		});
-
-		// Fake some data
-		$_SERVER['SCRIPT_NAME'] = '/sub/folder/index.php';
-		$_SERVER['REQUEST_URI'] = '/sub/folder/about/whatever';
-
-		$method = new ReflectionMethod(
-			'\Bramus\Router\Router', 'getCurrentUri'
-		);
-
-		$method->setAccessible(TRUE);
-
-		$this->assertEquals(
-			'/about/whatever', $method->invoke(new \Bramus\Router\Router())
-		);
-
-	}
-
-	public function testStaticRoute() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->match('GET', '/about', function() {
-			echo 'about';
-		});
-
-		// Test the /about route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/about';
-		$router->run();
-		$this->assertEquals('about', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testStaticRouteUsingShorthand() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/about', function() {
-			echo 'about';
-		});
-
-		// Test the /about route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/about';
-		$router->run();
-		$this->assertEquals('about', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testRequestMethods() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/', function() { echo 'get'; });
-		$router->post('/', function() { echo 'post'; });
-		$router->put('/', function() { echo 'put'; });
-		$router->patch('/', function() { echo 'patch'; });
-		$router->delete('/', function() { echo 'delete'; });
-		$router->options('/', function() { echo 'options'; });
-
-		// Test GET
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/';
-		$router->run();
-		$this->assertEquals('get', ob_get_contents());
-
-		// Test POST
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$router->run();
-		$this->assertEquals('post', ob_get_contents());
-
-		// Test PUT
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'PUT';
-		$router->run();
-		$this->assertEquals('put', ob_get_contents());
-
-		// Test PATCH
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'PATCH';
-		$router->run();
-		$this->assertEquals('patch', ob_get_contents());
-
-		// Test DELETE
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'DELETE';
-		$router->run();
-		$this->assertEquals('delete', ob_get_contents());
-
-		// Test OPTIONS
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'OPTIONS';
-		$router->run();
-		$this->assertEquals('options', ob_get_contents());
-
-		// Test HEAD
-		ob_clean();
-		$_SERVER['REQUEST_METHOD'] = 'HEAD';
-		$router->run();
-		$this->assertEquals('', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRoute() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/hello/(\w+)', function($name) {
-			echo 'Hello ' . $name;
-		});
-
-		// Test the /hello/bramus route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus';
-		$router->run();
-		$this->assertEquals('Hello bramus', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithMultiple() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/hello/(\w+)/(\w+)', function($name, $lastname) {
-			echo 'Hello ' . $name . ' ' . $lastname;
-		});
-
-		// Test the /hello/bramus route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus/sumarb';
-		$router->run();
-		$this->assertEquals('Hello bramus sumarb', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithOptionalSubpatterns() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/hello(/\w+)?', function($name = null) {
-			echo 'Hello ' . (($name) ? $name : 'stranger');
-		});
-
-		// Test the /hello route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello';
-		$router->run();
-		$this->assertEquals('Hello stranger', ob_get_contents());
-
-		// Test the /hello/bramus route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus';
-		$router->run();
-		$this->assertEquals('Hello bramus', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithMultipleSubpatterns() {
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/(.*)/page([0-9]+)', function($place, $page) {
-			echo 'Hello ' . $place . ' page : ' . $page;
-		});
-
-		// Test the /hello/bramus/page3 route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus/page3';
-		$router->run();
-		$this->assertEquals('Hello hello/bramus page : 3', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithOptionalNestedSubpatterns() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/blog(/\d{4}(/\d{2}(/\d{2}(/[a-z0-9_-]+)?)?)?)?', function($year = null, $month = null, $day = null, $slug = null) {
-			if (!$year) { echo 'Blog overview'; return; }
-			if (!$month) { echo 'Blog year overview (' . $year . ')'; return; }
-			if (!$day) { echo 'Blog month overview (' . $year . '-' . $month . ')'; return; }
-			if (!$slug) { echo 'Blog day overview (' . $year . '-' . $month . '-' . $day . ')'; return; }
-			echo 'Blogpost ' . htmlentities($slug) . ' detail (' . $year . '-' . $month . '-' . $day . ')';
-		});
-
-		// Test the /blog route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/blog';
-		$router->run();
-		$this->assertEquals('Blog overview', ob_get_contents());
-
-		// Test the /blog/year route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/blog/1983';
-		$router->run();
-		$this->assertEquals('Blog year overview (1983)', ob_get_contents());
-
-		// Test the /blog/year/month route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/blog/1983/12';
-		$router->run();
-		$this->assertEquals('Blog month overview (1983-12)', ob_get_contents());
-
-		// Test the /blog/year/month/day route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/blog/1983/12/26';
-		$router->run();
-		$this->assertEquals('Blog day overview (1983-12-26)', ob_get_contents());
-
-		// Test the /blog/year/month/day/slug route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/blog/1983/12/26/bramus';
-		$router->run();
-		$this->assertEquals('Blogpost bramus detail (1983-12-26)', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithNestedOptionalSubpatterns() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/hello(/\w+(/\w+)?)?', function($name1 = null, $name2 = null) {
-			echo 'Hello ' . (($name1) ? $name1 : 'stranger') . ' ' . (($name2) ? $name2 : 'stranger');
-		});
-
-		// Test the /hello/bramus route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus';
-		$router->run();
-		$this->assertEquals('Hello bramus stranger', ob_get_contents());
-
-		// Test the /hello/bramus/bramus route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus/bramus';
-		$router->run();
-		$this->assertEquals('Hello bramus bramus', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithWildcard() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('(.*)', function($name) {
-			echo 'Hello ' . $name;
-		});
-
-		// Test the /hello/bramus route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus';
-		$router->run();
-		$this->assertEquals('Hello hello/bramus', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	public function testDynamicRouteWithPartialWildcard() {
-
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/hello/(.*)', function($name) {
-			echo 'Hello ' . $name;
-		});
-
-		// Test the /hello/bramus route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/hello/bramus/sumarb';
-		$router->run();
-		$this->assertEquals('Hello bramus/sumarb', ob_get_contents());
-
-		// Cleanup
-		ob_end_clean();
-
-	}
-
-	/**
+    public function testUri() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->match('GET', '/about', function() {
+            echo 'about';
+        });
+
+        // Fake some data
+        $_SERVER['SCRIPT_NAME'] = '/sub/folder/index.php';
+        $_SERVER['REQUEST_URI'] = '/sub/folder/about/whatever';
+
+        $method = new ReflectionMethod(
+            '\Bramus\Router\Router', 'getCurrentUri'
+        );
+
+        $method->setAccessible(TRUE);
+
+        $this->assertEquals(
+            '/about/whatever', $method->invoke(new \Bramus\Router\Router())
+        );
+
+    }
+
+    public function testStaticRoute() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->match('GET', '/about', function() {
+            echo 'about';
+        });
+
+        // Test the /about route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/about';
+        $router->run();
+        $this->assertEquals('about', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testStaticRouteUsingShorthand() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/about', function() {
+            echo 'about';
+        });
+
+        // Test the /about route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/about';
+        $router->run();
+        $this->assertEquals('about', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testRequestMethods() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/', function() { echo 'get'; });
+        $router->post('/', function() { echo 'post'; });
+        $router->put('/', function() { echo 'put'; });
+        $router->patch('/', function() { echo 'patch'; });
+        $router->delete('/', function() { echo 'delete'; });
+        $router->options('/', function() { echo 'options'; });
+
+        // Test GET
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/';
+        $router->run();
+        $this->assertEquals('get', ob_get_contents());
+
+        // Test POST
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $router->run();
+        $this->assertEquals('post', ob_get_contents());
+
+        // Test PUT
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+        $router->run();
+        $this->assertEquals('put', ob_get_contents());
+
+        // Test PATCH
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+        $router->run();
+        $this->assertEquals('patch', ob_get_contents());
+
+        // Test DELETE
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'DELETE';
+        $router->run();
+        $this->assertEquals('delete', ob_get_contents());
+
+        // Test OPTIONS
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $router->run();
+        $this->assertEquals('options', ob_get_contents());
+
+        // Test HEAD
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+        $router->run();
+        $this->assertEquals('', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+    
+    public function testShorthandAll() {
+        
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->all('/', function() { echo 'all'; });
+        
+        $_SERVER['REQUEST_URI'] = '/';
+        
+        // Test GET
+        ob_start();
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test POST
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test PUT
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test DELETE
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'DELETE';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test OPTIONS
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test PATCH
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+        $router->run();
+        $this->assertEquals('all', ob_get_contents());
+        
+        // Test HEAD
+        ob_clean();
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+        $router->run();
+        $this->assertEquals('', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+        
+    }
+
+    public function testDynamicRoute() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/hello/(\w+)', function($name) {
+            echo 'Hello ' . $name;
+        });
+
+        // Test the /hello/bramus route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus';
+        $router->run();
+        $this->assertEquals('Hello bramus', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithMultiple() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/hello/(\w+)/(\w+)', function($name, $lastname) {
+            echo 'Hello ' . $name . ' ' . $lastname;
+        });
+
+        // Test the /hello/bramus route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus/sumarb';
+        $router->run();
+        $this->assertEquals('Hello bramus sumarb', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithOptionalSubpatterns() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/hello(/\w+)?', function($name = null) {
+            echo 'Hello ' . (($name) ? $name : 'stranger');
+        });
+
+        // Test the /hello route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello';
+        $router->run();
+        $this->assertEquals('Hello stranger', ob_get_contents());
+
+        // Test the /hello/bramus route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus';
+        $router->run();
+        $this->assertEquals('Hello bramus', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithMultipleSubpatterns() {
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/(.*)/page([0-9]+)', function($place, $page) {
+            echo 'Hello ' . $place . ' page : ' . $page;
+        });
+
+        // Test the /hello/bramus/page3 route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus/page3';
+        $router->run();
+        $this->assertEquals('Hello hello/bramus page : 3', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithOptionalNestedSubpatterns() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/blog(/\d{4}(/\d{2}(/\d{2}(/[a-z0-9_-]+)?)?)?)?', function($year = null, $month = null, $day = null, $slug = null) {
+            if (!$year) { echo 'Blog overview'; return; }
+            if (!$month) { echo 'Blog year overview (' . $year . ')'; return; }
+            if (!$day) { echo 'Blog month overview (' . $year . '-' . $month . ')'; return; }
+            if (!$slug) { echo 'Blog day overview (' . $year . '-' . $month . '-' . $day . ')'; return; }
+            echo 'Blogpost ' . htmlentities($slug) . ' detail (' . $year . '-' . $month . '-' . $day . ')';
+        });
+
+        // Test the /blog route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/blog';
+        $router->run();
+        $this->assertEquals('Blog overview', ob_get_contents());
+
+        // Test the /blog/year route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/blog/1983';
+        $router->run();
+        $this->assertEquals('Blog year overview (1983)', ob_get_contents());
+
+        // Test the /blog/year/month route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/blog/1983/12';
+        $router->run();
+        $this->assertEquals('Blog month overview (1983-12)', ob_get_contents());
+
+        // Test the /blog/year/month/day route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/blog/1983/12/26';
+        $router->run();
+        $this->assertEquals('Blog day overview (1983-12-26)', ob_get_contents());
+
+        // Test the /blog/year/month/day/slug route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/blog/1983/12/26/bramus';
+        $router->run();
+        $this->assertEquals('Blogpost bramus detail (1983-12-26)', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithNestedOptionalSubpatterns() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/hello(/\w+(/\w+)?)?', function($name1 = null, $name2 = null) {
+            echo 'Hello ' . (($name1) ? $name1 : 'stranger') . ' ' . (($name2) ? $name2 : 'stranger');
+        });
+
+        // Test the /hello/bramus route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus';
+        $router->run();
+        $this->assertEquals('Hello bramus stranger', ob_get_contents());
+
+        // Test the /hello/bramus/bramus route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus/bramus';
+        $router->run();
+        $this->assertEquals('Hello bramus bramus', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithWildcard() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('(.*)', function($name) {
+            echo 'Hello ' . $name;
+        });
+
+        // Test the /hello/bramus route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus';
+        $router->run();
+        $this->assertEquals('Hello hello/bramus', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    public function testDynamicRouteWithPartialWildcard() {
+
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/hello/(.*)', function($name) {
+            echo 'Hello ' . $name;
+        });
+
+        // Test the /hello/bramus route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/hello/bramus/sumarb';
+        $router->run();
+        $this->assertEquals('Hello bramus/sumarb', ob_get_contents());
+
+        // Cleanup
+        ob_end_clean();
+
+    }
+
+    /**
      * @runInSeparateProcess
      */
-	public function testDefault404() {
+    public function testDefault404() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/', function() {
-			echo 'home';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/', function() {
+            echo 'home';
+        });
 
-		// Test the /hello route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/foo';
-		$router->run();
-		$headers = xdebug_get_headers(); // @todo: this is empty??!
-		$this->assertEquals('', ob_get_contents());
+        // Test the /hello route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/foo';
+        $router->run();
+        $headers = xdebug_get_headers(); // @todo: this is empty??!
+        $this->assertEquals('', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function test404() {
+    public function test404() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/', function() {
-			echo 'home';
-		});
-		$router->set404(function() {
-			echo 'route not found';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/', function() {
+            echo 'home';
+        });
+        $router->set404(function() {
+            echo 'route not found';
+        });
 
-		// Test the /hello route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/';
-		$router->run();
-		$this->assertEquals('home', ob_get_contents());
+        // Test the /hello route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/';
+        $router->run();
+        $this->assertEquals('home', ob_get_contents());
 
-		// Test the /hello/bramus route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/foo';
-		$router->run();
-		$this->assertEquals('route not found', ob_get_contents());
+        // Test the /hello/bramus route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/foo';
+        $router->run();
+        $this->assertEquals('route not found', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testBeforeRouteMiddleware() {
+    public function testBeforeRouteMiddleware() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->before('GET', '/about', function() {
-			echo 'before ';
-		});
-		$router->get('/about', function() {
-			echo 'about';
-		});
-		$router->get('/contact', function() {
-			echo 'contact';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->before('GET', '/about', function() {
+            echo 'before ';
+        });
+        $router->get('/about', function() {
+            echo 'about';
+        });
+        $router->get('/contact', function() {
+            echo 'contact';
+        });
 
-		// Test the /about route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/about';
-		$router->run();
-		$this->assertContains('before', ob_get_contents());
+        // Test the /about route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/about';
+        $router->run();
+        $this->assertContains('before', ob_get_contents());
 
-		// Test the /contact route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/contact';
-		$router->run();
-		$this->assertNotContains('before', ob_get_contents());
+        // Test the /contact route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/contact';
+        $router->run();
+        $this->assertNotContains('before', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testBeforeRouterMiddleware() {
+    public function testBeforeRouterMiddleware() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->before('GET', '/.*', function() {
-			echo 'before ';
-		});
-		$router->get('/about', function() {
-			echo 'about';
-		});
-		$router->get('/contact', function() {
-			echo 'contact';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->before('GET', '/.*', function() {
+            echo 'before ';
+        });
+        $router->get('/about', function() {
+            echo 'about';
+        });
+        $router->get('/contact', function() {
+            echo 'contact';
+        });
 
-		// Test the /about route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/about';
-		$router->run();
-		$this->assertContains('before', ob_get_contents());
+        // Test the /about route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/about';
+        $router->run();
+        $this->assertContains('before', ob_get_contents());
 
-		// Test the /contact route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/contact';
-		$router->run();
-		$this->assertContains('before', ob_get_contents());
+        // Test the /contact route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/contact';
+        $router->run();
+        $this->assertContains('before', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testAfterRouterMiddleware() {
+    public function testAfterRouterMiddleware() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/', function() {
-			echo 'home';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/', function() {
+            echo 'home';
+        });
 
-		// Test the / route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/';
-		$router->run(function() { echo 'finished'; });
-		$this->assertEquals('homefinished', ob_get_contents());
+        // Test the / route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/';
+        $router->run(function() { echo 'finished'; });
+        $this->assertEquals('homefinished', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testSubfolders() {
+    public function testSubfolders() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->get('/', function() {
-			echo 'home';
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->get('/', function() {
+            echo 'home';
+        });
 
-		// Test the / route in a fake subfolder
-		ob_start();
-		$_SERVER['SCRIPT_NAME'] = '/about/index.php';
-		$_SERVER['REQUEST_URI'] = '/about/';
-		$router->run();
-		$this->assertEquals('home', ob_get_contents());
+        // Test the / route in a fake subfolder
+        ob_start();
+        $_SERVER['SCRIPT_NAME'] = '/about/index.php';
+        $_SERVER['REQUEST_URI'] = '/about/';
+        $router->run();
+        $this->assertEquals('home', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testSubrouteMouting() {
+    public function testSubrouteMouting() {
 
-		// Create Router
-		$router = new \Bramus\Router\Router();
-		$router->mount('/movies', function() use ($router) {
-			$router->get('/', function() {
-				echo 'overview';
-			});
-			$router->get('/(\d+)', function($id) {
-				echo htmlentities($id);
-			});
-		});
+        // Create Router
+        $router = new \Bramus\Router\Router();
+        $router->mount('/movies', function() use ($router) {
+            $router->get('/', function() {
+                echo 'overview';
+            });
+            $router->get('/(\d+)', function($id) {
+                echo htmlentities($id);
+            });
+        });
 
-		// Test the /movies route
-		ob_start();
-		$_SERVER['REQUEST_URI'] = '/movies';
-		$router->run();
-		$this->assertEquals('overview', ob_get_contents());
+        // Test the /movies route
+        ob_start();
+        $_SERVER['REQUEST_URI'] = '/movies';
+        $router->run();
+        $this->assertEquals('overview', ob_get_contents());
 
-		// Test the /hello/bramus route
-		ob_clean();
-		$_SERVER['REQUEST_URI'] = '/movies/1';
-		$router->run();
-		$this->assertEquals('1', ob_get_contents());
+        // Test the /hello/bramus route
+        ob_clean();
+        $_SERVER['REQUEST_URI'] = '/movies/1';
+        $router->run();
+        $this->assertEquals('1', ob_get_contents());
 
-		// Cleanup
-		ob_end_clean();
+        // Cleanup
+        ob_end_clean();
 
-	}
+    }
 
-	public function testHttpMethodOverride() {
+    public function testHttpMethodOverride() {
 
-		// Fake the request method to being POST and override it
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
+        // Fake the request method to being POST and override it
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
 
-		$method = new ReflectionMethod(
-			'\Bramus\Router\Router', 'getRequestMethod'
-		);
+        $method = new ReflectionMethod(
+            '\Bramus\Router\Router', 'getRequestMethod'
+        );
 
-		$method->setAccessible(TRUE);
+        $method->setAccessible(TRUE);
 
-		$this->assertEquals(
-			'PUT', $method->invoke(new \Bramus\Router\Router())
-		);
+        $this->assertEquals(
+            'PUT', $method->invoke(new \Bramus\Router\Router())
+        );
 
-	}
+    }
 
 }
 


### PR DESCRIPTION
* cleaning;
* set the `notFound` property to protected, to be able to fully extend the class (can be useful if we want to extend `Router::run`);
* add the argument `$trigger404` to `Router::run`, set by default to true. If true, it will (as it says :tongue:) trigger the notFound closure;
* add a `Router::all($pattern, $fn)` method.

Some other modifications might be needed to follow the idea of having an extensible class (like set some more properties from `private` to `protected`, etc).

If you see anything wrong in those commits, tell me, I'll try my best to fix them. :smiley: 