### PR TITLE
PHPUnit Outdated version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7",
-        "phpunit/php-code-coverage": "~1.2"
+        "phpunit/phpunit": "5.5.*",
+        "phpunit/php-code-coverage": "^4.0.1"
     },
     "autoload": {
         "psr-0": {"Bramus": "src/"}


### PR DESCRIPTION
The used version of phpunit are outdated and cause some issues. As
```PHP Fatal error:  Class PHPUnit_Util_DeprecatedFeature_Logger contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (PHPUnit_Framework_TestListener::addRiskyTest)```

 Oh, phpunit/phpunit 5.5.* requires phpunit/php-code-coverage ^4.0.1. So..