### PR TITLE
Enables setting a custom base path

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -387,4 +387,14 @@ class Router
 
         return $this->serverBasePath;
     }
+
+    /**
+     * Set a custom base path.
+     *
+     * @param string $path The base path.
+     */
+    protected function setBasePath($path)
+    {
+		$this->serverBasePath = $path;
+    }
 }


### PR DESCRIPTION
It's useful to be able to set the base path manually. For example if you're working with PHP's standalone server and you want the whole path to be taken into account.