### PR TITLE
Support the command line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bramus/router",
+    "name": "sn01615/router",
     "description": "A lightweight and simple object oriented PHP Router",
     "keywords": ["router", "routing"],
     "homepage": "https://github.com/bramus/router",

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -410,6 +410,7 @@ class Router
             if (isset($_SERVER['argc']) && $_SERVER['argc'] > 0) {
                 if (isset($_SERVER['argv'][1])) {
                     $uri = $_SERVER['argv'][1];
+                    $uri = '/' . trim($uri, '/');
                 }
             }
         }


### PR DESCRIPTION
```
PS E:\Working\wwwroot\router> ./vendor/bin/phpunit --bootstrap vendor/autoload.php -v
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:        PHP 7.1.4 with Xdebug 2.5.3
Configuration:  E:\Working\wwwroot\router\phpunit.xml.dist

....RR...................

Time: 252 ms, Memory: 4.00MB

There were 2 risky tests:

1) RouterTest::testRequestMethods
Test code or tested code did not (only) close its own output buffers

2) RouterTest::testShorthandAll
Test code or tested code did not (only) close its own output buffers

OK, but incomplete, skipped, or risky tests!
Tests: 25, Assertions: 50, Risky: 2.
```