### PR TITLE
New feature (Show the function or method output)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ If most/all of your handling classes are in one and the same namespace, you can 
 $router->setNamespace('\App\Controllers');
 $router->get('/users/(\d+)', 'User@showProfile');
 $router->get('/cars/(\d+)', 'Car@showProfile');
+
+```
+
+### Display
+
+If you need display the return of method or function, you can use this:
+
+```php
+$router->setReturnOutput(true);
 ```
 
 ### Custom 404

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -49,6 +49,26 @@ class Router
     private $namespace = '';
 
     /**
+    * @var bool If true it shows the return of the call
+    */
+    private $outputReturn = false;
+
+    public function setReturnOutput(bool $output)
+    {
+
+        $this->outputReturn = $output;
+
+    }
+
+    public function isReturnEnabled() 
+    {
+
+        return $this->outputReturn;
+
+    }
+
+
+    /**
      * Store a before middleware route and a handling function to be executed when accessed using one of the specified methods.
      *
      * @param string          $methods Allowed methods, | delimited
@@ -375,7 +395,10 @@ class Router
 
     private function invoke($fn, $params = array()) {
         if (is_callable($fn)) {
-            call_user_func_array($fn, $params);
+
+            $call = call_user_func_array($fn, $params);
+            if($this->isReturnEnabled()) echo $call;
+
         } // If not, check the existence of special parameters
         elseif (stripos($fn, '@') !== false) {
             // Explode segments of given route
@@ -388,10 +411,13 @@ class Router
             if (class_exists($controller)) {
                 // First check if is a static method, directly trying to invoke it.
                 // If isn't a valid static method, we will try as a normal method invocation.
-                if (call_user_func_array(array(new $controller(), $method), $params) === false) {
-                    // Try to call the method as an non-static method. (the if does nothing, only avoids the notice)
+                $call = call_user_func_array(array(new $controller(), $method), $params);
+                if($this->isReturnEnabled()) echo $call;
+
+                if ($call === false) {
                     if (forward_static_call_array(array($controller, $method), $params) === false);
                 }
+
             }
         }
     }


### PR DESCRIPTION
Just a simple functionality that I did when I needed a change in my system, some frameworks show the method or function return and my system was working like this, now im using and had to implement this.
Example:
```php
$Router->get('/', function () { 
     return 'hello'; 
});
$Router->setReturnOutput(true); // will show the return of function or method
$Router->run();
```
