### PR TITLE
Fix Base Path, Controller called twice if returned false, Code Optimized

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -419,7 +419,8 @@ class Router
 
             # Check if class exsist
             if(!class_exists($controller)){
-                return false;
+                throw new \ErrorException("Bramus\Router: class '{$context['controller']}' was not found" 0);
+                return;
             }
 
             # Call method

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -444,7 +444,7 @@ class Router
 
             # Check if class exsist
             if(!class_exists($controller)){
-                throw new \ErrorException("Bramus\Router: class '{$context['controller']}' was not found" 0);
+                throw new \ErrorException("Bramus\Router: class '{$context['controller']}' was not found", 0);
                 return;
             }
 

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -41,7 +41,7 @@ class Router
     /**
      * @var string The Server Base Path for Router Execution
      */
-    private $serverBasePath;
+    private $serverBasePath = '/';
 
     /**
      * @var string Default Controllers Namespace
@@ -421,12 +421,8 @@ class Router
      * @return string
      */
     protected function getBasePath()
-    {
-        // Check if server base path is defined, if not define it.
-        if ($this->serverBasePath === null) {
-            $this->serverBasePath = implode('/', array_slice(explode('/', $_SERVER['SCRIPT_NAME']), 0, -1)).'/';
-        }
-
+    {   
+        // Return base path
         return $this->serverBasePath;
     }
 }

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -53,6 +53,7 @@ class Router
      * Parse a pattern
      *
      * @param string $pattern A route pattern such as /about/system
+     *
      * @return string
      */
     private function parsePattern(String $pattern){
@@ -67,6 +68,8 @@ class Router
      * @param string          $methods Allowed methods, | delimited
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function before(String $methods, String $pattern, $fn)
     {
@@ -87,6 +90,8 @@ class Router
      * @param string          $methods Allowed methods, | delimited
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function match(String $methods, String $pattern, $fn)
     {
@@ -105,6 +110,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function all(String $pattern, $fn)
     {
@@ -116,6 +123,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function get(String $pattern, $fn)
     {
@@ -127,6 +136,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function post(String $pattern, $fn)
     {
@@ -138,6 +149,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function patch(String $pattern, $fn)
     {
@@ -149,6 +162,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function delete(String $pattern, $fn)
     {
@@ -160,6 +175,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function put(String $pattern, $fn)
     {
@@ -171,6 +188,8 @@ class Router
      *
      * @param string          $pattern A route pattern such as /about/system
      * @param object|callable $fn      The handling function to be executed
+     *
+     * @return void
      */
     public function options(String $pattern, $fn)
     {
@@ -182,6 +201,8 @@ class Router
      *
      * @param string   $baseRoute The route sub pattern to mount the callbacks on
      * @param callable $fn        The callback method
+     *
+     * @return void
      */
     public function mount(String $baseRoute, $fn)
     {
@@ -265,6 +286,8 @@ class Router
      * Set a Default Lookup Namespace for Callable methods.
      *
      * @param string $namespace A given namespace
+     *
+     * @return void
      */
     public function setNamespace(String $namespace)
     {
@@ -333,6 +356,8 @@ class Router
      * Set the 404 handling function.
      *
      * @param object|callable $fn The function to be executed
+     *
+     * @return void
      */
     public function set404($fn)
     {


### PR DESCRIPTION
This PR should fix #82 and fix #72.

Added Type Hints.  
Added `setBasePath` method (public) to set a base path.  
Added `parsePattern` method (private) to parse pattern.  
Added some comments on methods that don't have them.  
Property `serverBasePath` will have a default value of `/`.  
Changed some comments to make them shorter or understandable.  
Changed some variable names to make them easier to understand.  
Changed `array()` to `[]` just for cleanness. 
Changed how some checks are performed.  
Changed how `getBasePath` method behaves.  
Changed how `invoke` method behave and will now throw `ErrorException` if the class is not found.  
Changed how `invoke` method behave and will now throw `ErrorException` if a method is not found.  
Changed how `invoke` method handles warning from suppressing to now elevate it as Exception.  

There might be some changes that are not documented here. Please compare the files just be be sure.
