### PR TITLE
Fix #72

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -391,10 +391,7 @@ class Router
             if (class_exists($controller)) {
                 // First check if is a static method, directly trying to invoke it.
                 // If isn't a valid static method, we will try as a normal method invocation.
-                if (call_user_func_array([new $controller(), $method], $params) === false) {
-                    // Try to call the method as an non-static method. (the if does nothing, only avoids the notice)
-                    if (forward_static_call_array([$controller, $method], $params) === false);
-                }
+                call_user_func_array([new $controller(), $method], $params);
             }
         }
     }


### PR DESCRIPTION
Note: I'm using PHP 7.2.14

Hi,
I'm back to this repo again, and when I'm using this, I decided to test something, according to issue #72, the controller will be called twice if the controller returned `false`, and the issue had been spotted. It's because the code was anticipating if the class's method is static, then it should be statically called.

Here's my testing:
```php
public static function index(){
    echo 'x';
    return false;
}
```
The code above resulted in 2 `x` getting echoed out. (Result: `xx`)
```php
public function index(){
    echo 'x';
    return false;
}
```
The code above resulted in an Exception `ErrorException (E_DEPRECATED)
forward_static_call_array() expects parameter 1 to be a valid callback, non-static method App\Controllers\HomeController::index() should not be called statically`.

But when I removed those checks and replaced it with `call_user_func_array([new $controller(), $method], $params);` (can be seen in the changes), the method were only called once. This works no matter if the method is static or not.

I hope this will fix the issue and will not cause problems with other PHP versions.