### PR TITLE
Allow request URI and method to be overridden in the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Built by Bram(us) Van Damme _([https://www.bram.us](https://www.bram.us))_ and [
 - Dynamic Route Patterns: [Dynamic PCRE-based Route Patterns](#dynamic-pcre-based-route-patterns) or [Dynamic Placeholder-based Route Patterns](#dynamic-placeholder-based-route-patterns)
 - [Optional Route Subpatterns](#optional-route-subpatterns)
 - [Supports `X-HTTP-Method-Override` header](#overriding-the-request-method)
+- [Optional server side URI and method overrides](#server-side-request-overrides)
 - [Subrouting / Mounting Routes](#subrouting--mounting-routes)
 - [Allowance of `Class@Method` calls](#classmethod-calls)
 - [Custom 404 handling](#custom-404)
@@ -342,6 +343,14 @@ Note: If the route handling function has `exit()`ed the run callback won't be ru
 
 Use `X-HTTP-Method-Override` to override the HTTP Request Method. Only works when the original Request Method is `POST`. Allowed values for `X-HTTP-Method-Override` are `PUT`, `DELETE`, or `PATCH`.
 
+### Server side request overrides
+
+Run one or both of the following methods to manually override the request URI and/or request method. Useful if you're unable to rewrite your request or need to transmit the route URI another way. Can also be used for custom method overwriting with a form input variable instead of the above `X-HTTP-Method-Override` header, where that may be stripped or disallowed by the web server.
+
+```php
+$router->setRequestMethodOverride('POST');
+$router->setRequestUriOverride('/movies');
+```
 
 ### Subfolder support
 

--- a/demo/index.php
+++ b/demo/index.php
@@ -93,6 +93,28 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
         });
     });
 
+    // Optional request overrides, based on your own app logic.
+	/*try
+	{
+		// This will overwrite the request method
+		$router->setRequestMethodOverride('POST');
+	}
+	catch(\Exception $e)
+	{
+		if($e->getCode() == 405)
+		{
+			// The requested method was not allowed to be set, the router will now default to the requests HTTP method.
+			// Handle the exception yourself, or ignore it.
+		}
+		else
+		{
+			// Handle the exception yourself, or ignore it.
+		}
+	}*/
+
+	// This will overwrite the request URI, for example if it was sent over another header or as part of a larger payload to the server
+	//$router->setRequestUriOverride('/movies');
+
     // Thunderbirds are go!
     $router->run();
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -997,6 +997,13 @@ namespace {
 			// Cleanup
 			ob_end_clean();
 		}
+
+		public function testInvalidHttpMethodCannotBeProvided()
+		{
+			$router = new \Bramus\Router\Router();
+			$this->setExpectedException('\Exception');
+			$router->setRequestMethodOverride('POSTAL');
+		}
     }
 }
 


### PR DESCRIPTION
I've added two new methods to override the request URI and method should it be required.

```php
setRequestMethodOverride()
setRequestUriOverride()
```

For my purpose, this allows me to specify a basic route in a query string of another pages request and pass that to the router. Don't ask! I also added the method override so the same can be done. My use case: `index.php?page=api&method=POST&route=/movies`. Isn't legacy software great!

Issue #88 requested support for a `_method` field in POST forms, this PR will allow users to integrate that in their app without breaking compatibility with existing installations.

I've added three tests with several assertions and to ensure the server side overrides take precedent over `X-HTTP-Method-Override` (as if the developer feels the need to use the new methods, that header should be disregarded, the developer is still free to use it in their own method determination logic).

The README and demo's have also been updated.

Thanks for the great router, I hope this can help someone!