### PR TITLE
updates README requirements from PHP 5.3 to PHP 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built by Bram(us) Van Damme _([https://www.bram.us](https://www.bram.us))_ and [
 
 ## Prerequisites/Requirements
 
-- PHP 5.3 or greater
+- PHP 5.6 or greater
 - [URL Rewriting](https://gist.github.com/bramus/5332525)
 
 


### PR DESCRIPTION
The README currently states that PHP 5.3 or greater is required, however the codebase uses array short notation (e.g. `['hello', 'world']`) which was not supported until PHP 5.4. The earliest version referenced in travis.yml is PHP 5.6. 