### PR TITLE
Fixes issue #72

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -387,14 +387,9 @@ class Router
             if ($this->getNamespace() !== '') {
                 $controller = $this->getNamespace() . '\\' . $controller;
             }
-            // Check if class exists, if not just ignore and check if the class exists on the default namespace
-            if (class_exists($controller)) {
-                // First check if is a static method, directly trying to invoke it.
-                // If isn't a valid static method, we will try as a normal method invocation.
-                if (call_user_func_array([new $controller(), $method], $params) === false) {
-                    // Try to call the method as an non-static method. (the if does nothing, only avoids the notice)
-                    if (forward_static_call_array([$controller, $method], $params) === false);
-                }
+            // Check if method/class exists, if not just ignore
+            if (method_exists($controller, $method)) {
+                call_user_func_array([$controller, $method], $params);
             }
         }
     }

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -388,7 +388,7 @@ class Router
                 $controller = $this->getNamespace() . '\\' . $controller;
             }
             // Check if method/class exists, if not just ignore
-            if (method_exists($controller, $method)) {
+            if (is_callable([$controller, $method])) {
                 call_user_func_array([$controller, $method], $params);
             }
         }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -865,6 +865,29 @@ namespace {
                 $method->invoke(new \Bramus\Router\Router())
             );
         }
+
+        public function testControllerMethodReturningFalse()
+        {
+            // Create Router
+            $router = new \Bramus\Router\Router();
+            $router->get('/false', 'RouterTestController@returnFalse');
+            $router->get('/static-false', 'RouterTestController@staticReturnFalse');
+
+            // Test returnFalse
+            ob_start();
+            $_SERVER['REQUEST_URI'] = '/false';
+            $router->run();
+            $this->assertEquals('returnFalse', ob_get_contents());
+
+            // Test staticReturnFalse
+            ob_clean();
+            $_SERVER['REQUEST_URI'] = '/static-false';
+            $router->run();
+            $this->assertEquals('staticReturnFalse', ob_get_contents());
+
+            // Cleanup
+            ob_end_clean();
+        }
     }
 }
 
@@ -874,6 +897,20 @@ namespace {
         public function show($id)
         {
             echo $id;
+        }
+
+        public function returnFalse()
+        {
+            echo 'returnFalse';
+
+            return false;
+        }
+
+        public static function staticReturnFalse()
+        {
+            echo 'staticReturnFalse';
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This fix is similar to the pull request from @PlanetTheCloud, but slightly different.

It replaces **class_exists()** with **is_callable()** (why not check both, right?). It also passes the class _name_ to call_user_func_array() instead of an instance of the class (perhaps this is better performance or less error prone in the case that the class cannot be instantiated, although I haven't tested either of those claims).

A test is included as well.