### PR TITLE
Allows post requests with no url regex matches

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -385,7 +385,11 @@ class Router
     private function invoke($fn, $params = array())
     {
         if (is_callable($fn)) {
-            call_user_func_array($fn, $params);
+            if (count($params)) {
+                call_user_func_array($fn, $params);
+            } else {
+                call_user_func_array($fn, array('empty'));
+            }
         }
 
         // If not, check the existence of special parameters


### PR DESCRIPTION
I want the ability to have post routes as api endpoints for a single page application
```
$router->post('/login', function () {
    // Do something with $_POST
    echo json_encode($_POST);
});
```
But this throws an error in Router.php: `Uncaught ArgumentCountError: Too few arguments to function` because post routes expects a pattern match: https://github.com/bramus/router/blob/master/src/Bramus/Router/Router.php#L120

This PR will fix this