### PR TITLE
switch PSR-0 -> PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "friendsofphp/php-cs-fixer": "~2.14"
     },
     "autoload": {
-        "psr-0": {"Bramus": "src/"}
+        "psr-4": {"Bramus\\": "src/Bramus/"}
     },
     "scripts": {
         "test": "./vendor/bin/phpunit --colors=always",


### PR DESCRIPTION
PSR-0 is deprecated per https://www.php-fig.org/psr/psr-0/

notably PSR-4 allows us to remove the entire Bramus folder and put the router in src/Router/Router.php 
while PSR-0 did not allow us to do that, but whether or not that should be done, idk, this is just the minimum changes needed to use PSR-4.