### PR TITLE
Dropped PHP 5 Support -> now 7.2 or greater

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
       image: shivammathur/node:2004
     strategy:
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         dependencies: ['', '--prefer-lowest --prefer-stable']
     steps:
       - name: Checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
       image: shivammathur/node:2004
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.2', '7.3', '7.4']
         dependencies: ['', '--prefer-lowest --prefer-stable']
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built by Bram(us) Van Damme _([https://www.bram.us](https://www.bram.us))_ and [
 
 ## Prerequisites/Requirements
 
-- PHP 5.3 or greater
+- PHP 7.2 or greater
 - [URL Rewriting](https://gist.github.com/bramus/5332525)
 
 


### PR DESCRIPTION
PHP version 5 is deprecated for 2,5 years now (2019-01-01), so I think it's time to move on. I dropped support till PHP 7.2 (that's actually deprecated as well, but just for 8 months) and tried to support PHP 8.0 but to achieve that, PHPUnit needs to release a new version, otherwise it keeps failing. When there is PHPUnit support for PHP 8.0, I'll make another PR :wink:

https://www.php.net/supported-versions.php