### PR TITLE
Repairing trigger404() bug such that 404 works again without custom 404 handler

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -367,11 +367,11 @@ class Router
                 ++$numHandled;
               }
             }
-            if($numHandled == 0 and $this->notFoundCallback['/']) {
-              $this->invoke($this->notFoundCallback['/']);
-            } elseif ($numHandled == 0) {
-              header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
-            }
+        }
+        if (($numHandled == 0) && (isset($this->notFoundCallback['/']))) {
+            $this->invoke($this->notFoundCallback['/']);
+        } elseif ($numHandled == 0) {
+            header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
         }
     }
 


### PR DESCRIPTION
Since @uvulpos 's commit on multiple 404 routes,
- bramus/router does NOT generate a 404 status code when there is no custom 404 handler
- bramus/router emits a warning (PHP 8) when there is no root ('/') custom 404 handler
when none of the routes match