### PR TITLE
Check before handling 404 routes

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -291,10 +291,8 @@ class Router
         if ($numHandled === 0 && isset($this->afterRoutes[$this->requestedMethod])) {
             $this->trigger404($this->afterRoutes[$this->requestedMethod]);
         } // If a route was handled, perform the finish callback (if any)
-        else {
-            if ($callback && is_callable($callback)) {
-                $callback();
-            }
+        elseif ($callback && is_callable($callback)) {
+            $callback();
         }
 
         // If it originally was a HEAD request, clean up after ourselves by emptying the output buffer

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -288,8 +288,10 @@ class Router
         }
 
         // If no route was handled, trigger the 404 (if any)
-        if ($numHandled === 0 && isset($this->afterRoutes[$this->requestedMethod])) {
-            $this->trigger404($this->afterRoutes[$this->requestedMethod]);
+        if ($numHandled === 0) {
+            if (isset($this->afterRoutes[$this->requestedMethod])) {
+                $this->trigger404($this->afterRoutes[$this->requestedMethod]);
+            }
         } // If a route was handled, perform the finish callback (if any)
         elseif ($callback && is_callable($callback)) {
             $callback();

--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -288,7 +288,7 @@ class Router
         }
 
         // If no route was handled, trigger the 404 (if any)
-        if ($numHandled === 0) {
+        if ($numHandled === 0 && isset($this->afterRoutes[$this->requestedMethod])) {
             $this->trigger404($this->afterRoutes[$this->requestedMethod]);
         } // If a route was handled, perform the finish callback (if any)
         else {


### PR DESCRIPTION
This PR fixes #182.

I have verified that PHPUnit tests still pass. On a side-note, the version of PHP unit in `composer.json` doesn't work with PHP 8 due to the deprecation of `each` that it uses. Might be worth updating it.