### PR TITLE
Support to catch reflection fail on controller method call from outsi…

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -7,6 +7,8 @@
  */
 namespace Bramus\Router;
 
+class InvalidControllerException extends \Exception {}
+
 /**
  * Class Router.
  */
@@ -468,6 +470,8 @@ class Router
                 $controller = $this->getNamespace() . '\\' . $controller;
             }
 
+            $invalidControllerMsg="controller class '$controller' with method '$method' is not invokable, the class and method should be non-abstract, and the method public";
+
             try {
                 $reflectedMethod = new \ReflectionMethod($controller, $method);
                 // Make sure it's callable
@@ -481,9 +485,11 @@ class Router
                         }
                         call_user_func_array(array($controller, $method), $params);
                     }
+                } else {
+                    throw new InvalidControllerException($invalidControllerMsg,1001);    
                 }
             } catch (\ReflectionException $reflectionException) {
-                // The controller class is not available or the class does not have the method $method
+                throw new InvalidControllerException($invalidControllerMsg,1002);
             }
         }
     }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -2,11 +2,25 @@
 
 namespace {
 
-    class Handler
+    class Handler {
+        public function notFound() {
+            echo "route not found";
+        }
+    }
+
+    abstract class AbstractTestController {
+        public abstract function doSomething1();
+    }
+    
+    class TestController extends AbstractTestController
     {
-        public function notfound()
+        public function doSomething1()
         {
-            echo 'route not found';
+            echo 'called';
+        }
+
+        private function doSomething2() {
+            echo 'called';
         }
     }
 
@@ -125,6 +139,45 @@ namespace {
 
             // Cleanup
             ob_end_clean();
+        }
+
+        private function invokeRoute($classRoute) {
+            // Create Router
+            $router = new \Bramus\Router\Router();
+
+            $router->get('/invokeMe', $classRoute);
+
+            $_SERVER['REQUEST_URI'] = '/invokeMe';
+            $router->run();
+        }
+
+         /**
+         * @expectedException \Bramus\Router\InvalidControllerException
+         */
+        public function testControllerClassExists()
+        {
+            $this->invokeRoute('NotExistingClass@doSomething1');
+        }
+
+         /**
+         * @expectedException \Bramus\Router\InvalidControllerException
+         */
+        public function testControllerMethodNonAbstract()
+        {
+            $this->invokeRoute('AbstractTestController@doSomething1');
+        }
+
+         /**
+         * @expectedException \Bramus\Router\InvalidControllerException
+         */
+        public function testControllerMethodPublic()
+        {
+            $this->invokeRoute('AbstractTestController@doSomething2');
+        }
+
+        public function testControllerMethodInvokable()
+        {
+            $this->invokeRoute('TestController@doSomething1');
         }
 
         public function testStaticRouteUsingShorthand()


### PR DESCRIPTION
…de the Router. Fixed missing class Handler (due to failed test after adding support for the former catching).

According to requested feature #185 https://github.com/bramus/router/issues/185

I hope it fulfills the feature accordingly. 