### PR TITLE
Added support for PHP FPM on PATCH/DELETE/PUT requests.

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -192,7 +192,7 @@ class Router
 	 */
 	public function getRequestHeaders()
 	{
-		function formatHeadersName(&$headers, $removeFirstChars = false)
+		function formatHeadersName($headers, $removeFirstChars = false)
 		{
 
 			foreach ($headers as $name => $value) {


### PR DESCRIPTION
Hi, on PHP FPM (in my case PHP FPM 7.4), the `getallheaders()` function returns an array with other keys than on PHP for Apache.
This causes the `PUT`, `DELETE`, or `PATCH` requests are not recognized and the request is processed like a `POST` request. This patch will keep the servers without the `getallheaders()` function to work.