### PR TITLE
Update Router.php

### DIFF
--- a/src/Bramus/Router/Router.php
+++ b/src/Bramus/Router/Router.php
@@ -291,6 +291,8 @@ class Router
         if ($numHandled === 0) {
             if (isset($this->afterRoutes[$this->requestedMethod])) {
                 $this->trigger404($this->afterRoutes[$this->requestedMethod]);
+            } else {
+                $this->trigger404();
             }
         } // If a route was handled, perform the finish callback (if any)
         elseif ($callback && is_callable($callback)) {


### PR DESCRIPTION
Fix error "Undefined array key" for 404 handler

For example routs
`$router = new \Bramus\Router\Router();

$router->post('/v1/init', function() {
    $response = [
        'data'=>'POST',
        'status' => 'success',
        'access'=>Header::getByKey('token'),
    ];
    echo json_encode($response);
});

$router->set404('/.*', function() {
    header('HTTP/1.1 404 Not Found');
    header('Content-Type: application/json');

    $jsonArray = array();
    $jsonArray['status'] = "404";
    $jsonArray['status_text'] = "route not defined";

    echo json_encode($jsonArray);
});

$router->run();`

If send any GET query, to got warning 
<br />
<b>Warning</b>:  Undefined array key "GET" in <b>/srv/app/vendor/bramus/router/src/Bramus/Router/Router.php</b> on line <b>292</b><br />
<br />
